### PR TITLE
Document LLVM/Ninja build setup

### DIFF
--- a/ANALYZE.MD
+++ b/ANALYZE.MD
@@ -19,22 +19,35 @@ apt-get install -y --no-install-recommends \
     graphviz \
     doxygen \
     cloc \
-    diffoscope \
     global \
     bpftrace \
-    bpfcc-tools
+    bpfcc-tools \
+    build-essential \
+    ninja-build \
+    clang \
+    lld \
+    llvm \
+    clang-format \
+    clang-tidy \
+    gdb \
+    valgrind \
+    cppcheck \
+    sloccount \
+    flawfinder \
+    linux-tools-common \
+    linux-tools-generic
 ```
 
 ### Python packages (pip)
 
 ```sh
-python -m pip install networkx matplotlib pydot sphinx lizard
+python -m pip install networkx matplotlib pydot sphinx lizard diffoscope pylint flake8 mypy semgrep
 ```
 
 ### Node packages (npm)
 
 ```sh
-npm install -g tree-sitter-cli
+npm install -g tree-sitter-cli eslint jshint jscpd nyc
 ```
 
 ### Package versions
@@ -45,7 +58,6 @@ npm install -g tree-sitter-cli
 - `graphviz 2.43.0`
 - `doxygen 1.9.8`
 - `cloc 1.98`
-- `diffoscope 259`
 - `global 6.6.11`
 - `bpftrace 0.20.2`
 - `tree-sitter 0.25.8`
@@ -54,6 +66,24 @@ npm install -g tree-sitter-cli
 - `pydot 4.0.1`
 - `sphinx 8.2.3`
 - `lizard 1.17.31`
+- `diffoscope 303`
+- `pylint 3.3.8`
+- `flake8 7.3.0`
+- `mypy 1.17.1`
+- `semgrep 1.131.0`
+- `clang 18.1.3`
+- `lld 18.1.3`
+- `llvm 18.1.3`
+- `ninja 1.11.1`
+- `gdb 15.0.50.20240403`
+- `valgrind 3.22.0`
+- `cppcheck 2.13.0`
+- `sloccount 2.26`
+- `flawfinder 2.0.19`
+- `eslint 9.33.0`
+- `jshint 2.13.6`
+- `jscpd 4.0.5`
+- `nyc 17.1.0`
 
 ## Configuration Files
 
@@ -100,3 +130,5 @@ The following packages were not exercised but complement the tracing workflow:
 - `D3.js` for web-based visualisation.
 - `CodeQL` or `Joern` for property-graph mining of security-relevant paths.
 
+
+See [docs/ANALYSIS_TOOLS.md](docs/ANALYSIS_TOOLS.md) for per-tool installation methods and sample outputs.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ Building
 
 DiscoBSD is cross-built on UNIX-like host operating systems.
 
+For detailed host preparation and Ninja/LLVM build guidance, consult
+[`docs/BUILDING.md`](docs/BUILDING.md).
+
 Currently supported host operating systems: OpenBSD, Linux, FreeBSD.
 
 Instructions to configure an OpenBSD host development environment for

--- a/docs/ANALYSIS_TOOLS.md
+++ b/docs/ANALYSIS_TOOLS.md
@@ -1,0 +1,151 @@
+# Analysis Tool Reference
+
+This guide captures installation methods, minimal configuration, and sample
+invocations for the tooling used to study and instrument DiscoBSD.
+
+## cloc
+- **Install**: `sudo apt install cloc`
+- **Config**: none
+- **Run**: `cloc tools`
+
+```text
+Language                     files          blank        comment           code
+C                              118           5809           5726          39112
+C/C++ Header                    53           1314           2291           7073
+...
+SUM:                           219           7661           8376          48397
+```
+
+## lizard
+- **Install**: `python -m pip install lizard`
+- **Config**: none
+- **Run**: `python -m lizard tools/trace_inventory.py`
+
+```text
+NLOC    Avg.NLOC  AvgCCN  Avg.token  function_cnt    file
+     59      15.5     3.0       90.0         2     tools/trace_inventory.py
+```
+
+## cscope
+- **Install**: `sudo apt install cscope`
+- **Config**: `find usr.bin/printf -name '*.c' > cscope.files`
+- **Run**: `cscope -b -i cscope.files`
+
+## diffoscope
+- **Install**: `python -m pip install diffoscope` + `sudo apt install file`
+- **Config**: none
+- **Run**: `diffoscope README.md README.md` *(no output; files identical)*
+
+## valgrind
+- **Install**: `sudo apt install valgrind`
+- **Config**: none
+- **Run**: `valgrind --tool=memcheck true`
+
+```text
+==6551== Memcheck, a memory error detector
+==6551== All heap blocks were freed -- no leaks are possible
+```
+
+## cppcheck
+- **Install**: `sudo apt install cppcheck`
+- **Config**: none
+- **Run**: `cppcheck usr.bin/printf`
+
+```text
+Checking usr.bin/printf/printf.c ...
+```
+
+## sloccount
+- **Install**: `sudo apt install sloccount`
+- **Config**: none
+- **Run**: `sloccount usr.bin/printf`
+
+```text
+SLOC    Directory       SLOC-by-Language (Sorted)
+310     printf          ansic=310
+```
+
+## flawfinder
+- **Install**: `sudo apt install flawfinder`
+- **Config**: none
+- **Run**: `flawfinder usr.bin/printf`
+
+```text
+usr.bin/printf/printf.c:45:  [4] (format) printf:
+  If format strings can be influenced by an attacker, they can be exploited
+```
+
+## gdb
+- **Install**: `sudo apt install gdb`
+- **Config**: none
+- **Run**: `gdb --version`
+
+```text
+GNU gdb (Ubuntu 15.0.50.20240403-0ubuntu1) 15.0.50.20240403-git
+```
+
+## pylint
+- **Install**: `python -m pip install pylint`
+- **Config**: none
+- **Run**: `python -m pylint tools/trace_inventory.py`
+
+```text
+Your code has been rated at 10.00/10
+```
+
+## flake8
+- **Install**: `python -m pip install flake8`
+- **Config**: none
+- **Run**: `python -m flake8 tools`
+
+```text
+tools/trace_callgraph.py:30:1: F401 'sys' imported but unused
+```
+
+## mypy
+- **Install**: `python -m pip install mypy`
+- **Config**: none
+- **Run**: `mypy tools`
+
+```text
+tools/build/autobuild.py:16: error: Missing parentheses in call to 'print'.
+```
+
+## semgrep
+- **Install**: `python -m pip install semgrep`
+- **Config**: none
+- **Run**: `semgrep --config=p/ci tools`
+
+```text
+✅ Scan completed successfully.
+```
+
+## eslint
+- **Install**: `npm install -g eslint`
+- **Config**: requires `eslint.config.js`
+- **Run**: `eslint tools` *(fails: configuration missing)*
+
+## jshint
+- **Install**: `npm install -g jshint`
+- **Config**: none
+- **Run**: `jshint tools` *(no output; no JavaScript files)*
+
+## jscpd
+- **Install**: `npm install -g jscpd`
+- **Config**: none
+- **Run**: `jscpd tools`
+
+```text
+Clone found (c):
+ - tools/virtualmips/jz4740/jz4740_dev_uart.c [263:42 - 272:4] ...
+```
+
+## nyc
+- **Install**: `npm install -g nyc`
+- **Config**: none
+- **Run**: `nyc --version`
+
+```text
+17.1.0
+```
+

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -1,0 +1,92 @@
+# Build and Instrumentation Guide
+
+This document replaces the former `setup.sh` script and describes how to
+configure a Linux host to build and analyse DiscoBSD using modern LLVM
+infrastructure and the Ninja build executor.
+
+## Prerequisites
+
+The commands below assume a Debian/Ubuntu host with `sudo` privileges.
+Package versions may evolve; verify them with `--version` when required.
+
+```sh
+sudo apt update
+sudo apt install -y \
+    build-essential \
+    ninja-build \
+    clang lld llvm \
+    clang-format clang-tidy \
+    gdb valgrind \
+    linux-tools-common linux-tools-generic
+```
+
+> `perf` is provided by the `linux-tools-*` packages.  A kernel-specific
+> package may be necessary when the running kernel version does not match the
+> `linux-tools-generic` release.
+
+Optional tooling used for static and dynamic analysis includes `ripgrep`,
+`universal-ctags`, `cscope`, `doxygen`, `graphviz`, `cppcheck`, `sloccount`,
+`flawfinder`, and a suite of linters outlined below.  Refer to `ANALYZE.MD`
+for an exhaustive list and version references.
+
+## Configuring LLVM and Ninja
+
+Ninja is the preferred entry point.  Assuming a `build.ninja` file exists (e.g.
+produced by CMake or a bespoke generator), invoke:
+
+```sh
+ninja
+```
+
+To generate debug-friendly artefacts with aggressive optimisation while
+retaining backtraces:
+
+```sh
+CFLAGS="-O2 -g -fno-omit-frame-pointer" \
+CXXFLAGS="-O2 -g -fno-omit-frame-pointer" \
+LDFLAGS="-fuse-ld=lld" \
+ninja
+```
+
+These flags leverage Clang and LLD for code generation and linking.  Adjust the
+`BOARD` or target-specific variables as required for embedded deployments.
+
+## Instrumentation Workflow
+
+- **`clang-tidy`** – static analysis: `clang-tidy path/to/file.c --`.
+- **`clang-format`** – style enforcement: `clang-format -i path/to/file.c`.
+- **`gdb`** – source-level debugging of produced binaries.
+- **`valgrind`** – dynamic analysis for memory errors: `valgrind ./a.out`.
+- **`perf`** – performance profiling when matching kernel tools are available.
+
+Refer to `ANALYZE.MD` for additional exploration utilities and their usage.
+
+## Tool Installation Matrix
+
+The following matrix summarises canonical installation avenues derived from
+project documentation and package manager manuals.
+
+```text
++-------------------+---------------------+--------------------------------------------------+
+| Tool              | Installation Method | Example Command                                  |
++-------------------+---------------------+--------------------------------------------------+
+| lizard            | pip                 | pip install lizard                               |
+| cloc              | apt                 | sudo apt install cloc                            |
+| cscope            | apt                 | sudo apt install cscope                          |
+| diffoscope        | pip                 | pip install diffoscope                           |
+| dtrace            | source build        | git clone https://github.com/dtrace4linux/linux.git && make -C linux && sudo make -C linux install |
+| valgrind          | apt                 | sudo apt install valgrind                        |
+| cppcheck          | apt                 | sudo apt install cppcheck                        |
+| sloccount         | apt                 | sudo apt install sloccount                       |
+| flawfinder        | apt                 | sudo apt install flawfinder                      |
+| gdb               | apt                 | sudo apt install gdb                             |
+| pylint            | pip                 | pip install pylint                               |
+| flake8            | pip                 | pip install flake8                               |
+| mypy              | pip                 | pip install mypy                                 |
+| semgrep           | pip                 | pip install semgrep                              |
+| eslint            | npm                 | npm install eslint                               |
+| jshint            | npm                 | npm install jshint                               |
+| jscpd             | npm                 | npm install jscpd                                |
+| nyc               | npm                 | npm install nyc                                  |
++-------------------+---------------------+--------------------------------------------------+
+```


### PR DESCRIPTION
## Summary
- Add `docs/ANALYSIS_TOOLS.md` detailing installation, configuration, and sample runs for each analysis and instrumentation tool
- Cross-link analysis reference from `ANALYZE.MD` for easier discovery

## Testing
- `sudo apt update`
- `clang --version`
- `ninja --version`
- `cloc tools`
- `python -m lizard tools/trace_inventory.py`
- `find usr.bin/printf -name '*.c' > cscope.files && cscope -b -i cscope.files`
- `/root/.pyenv/versions/3.12.10/bin/diffoscope README.md README.md` *(no output)*
- `valgrind --tool=memcheck true`
- `cppcheck usr.bin/printf`
- `sloccount usr.bin/printf`
- `flawfinder usr.bin/printf`
- `gdb --version`
- `python -m pylint tools/trace_inventory.py`
- `python -m flake8 tools`
- `mypy tools`
- `/root/.pyenv/versions/3.12.10/bin/semgrep --config=p/ci tools`
- `eslint tools` *(expected config error)*
- `jshint tools`
- `jscpd tools`
- `nyc --version`
- `make help`


------
https://chatgpt.com/codex/tasks/task_e_689b8751740c8331aed2265ff3a6bb0c