### PR TITLE
Refine kconfig build tooling documentation

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -17,12 +17,27 @@ sudo apt install -y \
     clang lld llvm \
     clang-format clang-tidy \
     gdb valgrind \
-    linux-tools-common linux-tools-generic
+    linux-tools-common linux-tools-generic \
+    byacc flex libfuse-dev pkg-config mandoc
 ```
 
 > `perf` is provided by the `linux-tools-*` packages.  A kernel-specific
 > package may be necessary when the running kernel version does not match the
 > `linux-tools-generic` release.
+
+Byacc and Flex supply the parser and lexer generators required for
+building the `kconfig` utility.  `mandoc` renders its manual page, while
+the `libfuse-dev` and `pkg-config` packages enable the optional
+FUSE-based `fsutil` tool.
+
+To verify the parser toolchain, explicitly select the host's parser and
+lexer generators and rebuild the configuration utility:
+
+```sh
+export YACC=byacc
+export LEX=flex
+make -C tools/kconfig clean all
+```
 
 Optional tooling used for static and dynamic analysis includes `ripgrep`,
 `universal-ctags`, `cscope`, `doxygen`, `graphviz`, `cppcheck`, `sloccount`,

--- a/tools/kconfig/Makefile
+++ b/tools/kconfig/Makefile
@@ -4,6 +4,8 @@ TOPSRC!=cd ../..; pwd
 
 CFLAGS		= -O -Wall
 
+LEX?=	flex
+
 # libbsd-dev package on Linux in overlay mode.
 CFLAGS+=	${_LIBBSD_CFLAGS}
 LIBS+=		${_LIBBSD_LIBS}
@@ -22,13 +24,25 @@ ${MAN}:		${MANSRC}
 		${MANROFF} ${MANSRC} > $@
 
 clean:
-		rm -f *~ *.o ${PROG} ${MAN} ${PROG}.dSYM y.tab.[ch] lang.c config.c
+	rm -f *~ *.o ${PROG} ${MAN} ${PROG}.dSYM y.tab.[ch] lang.c config.c
 
 $(PROG):	$(OBJS)
 		$(CC) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
 
+config.o: config.c y.tab.h config.h
 main.o: main.c y.tab.h config.h
-mkheaders.o: mkheaders.c config.h y.tab.h
 mkioconf.o: mkioconf.c y.tab.h config.h
 mkmakefile.o: mkmakefile.c y.tab.h config.h
 mkswapconf.o: mkswapconf.c config.h
+
+# Generate parser and lexer sources from the corresponding grammar.
+config.c y.tab.h: config.y
+	${YACC} -d config.y
+	mv -f y.tab.c config.c
+
+lang.c: lang.l y.tab.h
+	${LEX} -o lang.c lang.l
+
+lang.o: lang.c y.tab.h
+
+.PHONY: all install clean


### PR DESCRIPTION
## Summary
- allow overriding the lexer generator via a new `LEX` variable and mark primary targets phony
- document exporting `YACC` and `LEX` to rebuild the `kconfig` parser

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y byacc flex libfuse-dev pkg-config mandoc`
- `export YACC=byacc && export LEX=flex && make -C tools/kconfig`
- `mandoc -T ascii tools/kconfig/kconfig.8 | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68a7c50654b48331ba8b3141dfc4653f